### PR TITLE
define `cconvert` for `DenseStringViewAndSub` instead of only the `Sub`

### DIFF
--- a/src/StringViews.jl
+++ b/src/StringViews.jl
@@ -44,8 +44,8 @@ Base.pointer(x::SubString{<:DenseStringView}) = pointer(x.string) + x.offset
 Base.pointer(x::SubString{<:DenseStringView}, i::Integer) = pointer(x.string) + x.offset + (i-1)
 Base.unsafe_convert(::Type{Ptr{UInt8}}, s::DenseStringViewAndSub) = pointer(s)
 Base.unsafe_convert(::Type{Ptr{Int8}}, s::DenseStringViewAndSub) = convert(Ptr{Int8}, pointer(s))
-Base.cconvert(::Type{Ptr{UInt8}}, s::SubString{<:DenseStringView}) = s
-Base.cconvert(::Type{Ptr{Int8}}, s::SubString{<:DenseStringView}) = s
+Base.cconvert(::Type{Ptr{UInt8}}, s::DenseStringViewAndSub) = s
+Base.cconvert(::Type{Ptr{Int8}}, s::DenseStringViewAndSub) = s
 
 Base.sizeof(s::StringView) = length(s.data)
 Base.ncodeunits(s::StringView) = length(s.data)


### PR DESCRIPTION
Otherwise, a materialized `String` from the `StringView` will be created in any `ccall` (which kind of kills the point of the package since most things end up in a ccall). For example:

```jl
julia> sv = StringView("foo");

julia> @btime $sv == "foo" # allocations :(
  53.708 ns (2 allocations: 88 bytes)
true
```

After:

```jl
julia> @btime $sv == "foo" # no allocations :)
  5.037 ns (0 allocations: 0 bytes)
true
```

All the other stuff above is defined for `DenseStringViewAndSub` so is it just a typo that this wasn't the case for `cconvert` as well?
