### PR TITLE
Stop pirating Base._searchindex and Base._rsearchindex

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -77,12 +77,30 @@ end
 # The following functions require julia#37283 in Julia 1.6, which
 # allow us to search byte arrays (applied to codeunits(s)).
 @static if VERSION ≥ v"1.6.0-DEV.1341"
-    function Base._searchindex(s::Union{StringViewAndSub,StringAndSub}, t::Union{StringViewAndSub,StringAndSub}, i::Integer)
+    # Split into two identical methods to avoid pirating Base's methods, leading to ~370 invalidations.
+    function Base._searchindex(s::StringViewAndSub, t::Union{StringViewAndSub,StringAndSub}, i::Integer)
+        searchindex_internal(s, t, i)
+    end
+
+    function Base._searchindex(s::Union{StringViewAndSub,StringAndSub}, t::StringViewAndSub, i::Integer)
+        searchindex_internal(s, t, i)
+    end
+
+    function searchindex_internal(s::Union{StringViewAndSub,StringAndSub}, t::Union{StringViewAndSub,StringAndSub}, i::Integer)
         # Check for fast case of a single byte
         lastindex(t) == 1 && return something(findnext(isequal(t[1]), s, i), 0)
         Base._searchindex(codeunits(s), codeunits(t), i)
     end
-    function Base._rsearchindex(s::Union{StringViewAndSub,StringAndSub}, t::Union{StringViewAndSub,StringAndSub}, i::Integer)
+
+    function Base._rsearchindex(s::StringViewAndSub, t::Union{StringViewAndSub,StringAndSub}, i::Integer)
+        rsearchindex_internal(s, t, i)
+    end
+
+    function Base._rsearchindex(s::Union{StringViewAndSub,StringAndSub}, t::StringViewAndSub, i::Integer)
+        rsearchindex_internal(s, t, i)
+    end
+
+    function rsearchindex_internal(s::Union{StringViewAndSub,StringAndSub}, t::Union{StringViewAndSub,StringAndSub}, i::Integer)
         # Check for fast case of a single byte
         if lastindex(t) == 1
             return something(findprev(isequal(t[1]), s, i), 0)


### PR DESCRIPTION
Before, these methods were extended with new signatures using big unions. These big unions included Base types, which meant that certain methodinstances using concrete types of Base was being invalidated unnecessarily.

This PR stops the type piracy, cutting invalidations from 2000 -> 362 on recent Julia master.
This number of invalidations is much improved compared to Julia 1.8.2 due to recent invalidation hunting.

I think it's still worth investigating why `StringViews` cause so many invalidations.
Superficial snoop compiling suggests that a blank slate Julia sessions has a lot of abstract methodinstances related to strings compiled, such as `thisind(::AbstractString, ::Int64)`.
If I understand SnoopCompile correctly, this means the problem might be in Base, not in this package.