### PR TITLE
make copy(::StringView) return a StringView (with copied data)

### DIFF
--- a/src/StringViews.jl
+++ b/src/StringViews.jl
@@ -35,7 +35,7 @@ Base.String(s::StringViewAndSub) = String(copyto!(Base.StringVector(ncodeunits(s
 StringView(s::StringView) = s
 StringView(s::String) = StringView(codeunits(s))
 
-Base.copy(s::StringView) = String(s)
+Base.copy(s::StringView) = StringView(copy(s.data))
 
 Base.Symbol(s::DenseStringViewAndSub) =
     return ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), s, ncodeunits(s))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,10 @@ su = StringView("föôẞαr")
     @test Vector{UInt8}(abc) == collect(0x61:0x63)
     @test Symbol(s) == :foobar
     @test Symbol(abc) == :abc
-    @test copy(s)::String == "foobar"
+    c = copy(s)
+    @test c isa StringView
+    @test c == "foobar"
+    @test c.data !== s.data
 
     @test StringView("foo") isa StringView{Base.CodeUnits{UInt8,String}}
 


### PR DESCRIPTION
On second thought, it seems better for `copy` to return the same type.