### PR TITLE
add efficient conversion from CString

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "354b36f9-a18e-4713-926e-db85100087ba"
 authors = ["Steven G. Johnson <stevenj@alum.mit.edu>"]
 version = "1.3.3"
 
+[deps]
+UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
+
 [compat]
 julia = "1.6"
 


### PR DESCRIPTION
UnsafeArrays just provides a DenseArray wrapper around a pointer and length. Hope that adding this dep is fine!
In return, it gives almost zero-cost conversion from CString.