### PR TITLE
Bugfix: Allow regex captures of substrings of stringviews

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StringViews"
 uuid = "354b36f9-a18e-4713-926e-db85100087ba"
 authors = ["Steven G. Johnson <stevenj@alum.mit.edu>"]
-version = "1.3.3"
+version = "1.3.4"
 
 [compat]
 julia = "1.6"

--- a/src/regex.jl
+++ b/src/regex.jl
@@ -28,8 +28,9 @@ function Base.match(re::Regex, str::T, idx::Integer, add_opts::UInt32=UInt32(0))
     end
     n = div(PCRE.ovec_length(data), 2) - 1
     p = PCRE.ovec_ptr(data)
-    mat = SubString(str, unsafe_load(p, 1)+1, prevind(str, unsafe_load(p, 2)+1))
-    cap = Union{Nothing,SubString{T}}[unsafe_load(p,2i+1) == PCRE.UNSET ? nothing :
+    SS = T <: SubString ? T : SubString{T}
+    mat = SubString(str, unsafe_load(p, 1)+1, prevind(str, unsafe_load(p, 2)+1))::SS
+    cap = Union{Nothing,SS}[unsafe_load(p,2i+1) == PCRE.UNSET ? nothing :
                                            SubString(str, unsafe_load(p,2i+1)+1,
                                            prevind(str, unsafe_load(p,2i+2)+1)) for i=1:n]
     off = Int[ unsafe_load(p,2i+1)+1 for i=1:n ]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,10 @@ end
     sv = StringView(codeunits("foo 1234 bar"))
     @test match(r"[0-9]+", sv).match.string === sv
     @test eltype(eachmatch(r"[0-9]+", sv)) == SVRegexMatch{typeof(sv)}
+
+    # Regex match of substring of stringview
+    strv = only(match(r"^([a-z]+)$", SubString(StringView((b"abc")))))
+    @test typeof(strv) == SubString{StringView{typeof(b"abc")}}
 end
 
 @testset "named subpatterns" begin


### PR DESCRIPTION
A substring of `SubString{T}` is not `SubString{SubString{T}}`, which the previous code assumed, but just `SubString{T}`.

Closes #26 