### PR TITLE
fix StringView(buf) inbounds for nightly

### DIFF
--- a/src/StringViews.jl
+++ b/src/StringViews.jl
@@ -43,8 +43,10 @@ StringView{S}(s::StringView{S}) where {S<:AbstractVector{UInt8}} = s
 StringView(s::String) = StringView(codeunits(s))
 
 # iobuffer constructor (note that buf.data is always 1-based)
-StringView(buf::IOBuffer, r::OrdinalRange{<:Integer,<:Integer}=Base.OneTo(buf.ptr-1)) =
+@inline function StringView(buf::IOBuffer, r::OrdinalRange{<:Integer,<:Integer}=Base.OneTo(buf.ptr-1))
+    @boundscheck issubset(r, Base.OneTo(buf.size)) || throw(BoundsError(buf, r))
     StringView(@view buf.data[r])
+end
 
 Base.copy(s::StringView) = StringView(copy(s.data))
 


### PR DESCRIPTION
Hopefully fixes the CI failure on nightly.  Apparently `take!` doesn't result in `buf.data` being empty anymore.